### PR TITLE
Make marker cam recoverable

### DIFF
--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -234,8 +234,10 @@ public:
   {
     // grab the image
     cam_.grab_image(&img_);
-    if (ENODEV == errno) return false;
-
+    if (ENODEV == errno) {
+        cam_.shutdown(); 
+        return false;
+    }
     // grab the camera info
     sensor_msgs::CameraInfoPtr ci(new sensor_msgs::CameraInfo(cinfo_->getCameraInfo()));
     ci->header.frame_id = img_.header.frame_id;

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -526,7 +526,7 @@ int UsbCam::read_frame()
 
             /* fall through */
 
-          case ENODEV:
+          case ENODEV:  // @WZ: added to handle disconnection
             ROS_WARN("Connection to camera has been lost.");
             return 0;
 
@@ -606,10 +606,11 @@ void UsbCam::stop_capturing(void)
     case IO_METHOD_USERPTR:
       type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 
-      if (-1 == xioctl(fd_, VIDIOC_STREAMOFF, &type))
-        if (errno != ENODEV)
+      if (-1 == xioctl(fd_, VIDIOC_STREAMOFF, &type)) {
+        if (errno != ENODEV) {
           errno_exit("VIDIOC_STREAMOFF");
-
+        }
+      }
       break;
   }
 }
@@ -618,7 +619,7 @@ void UsbCam::start_capturing(void)
 {
 
   if(is_capturing_) return;
-  if (fd_ == -1) return;
+  if (fd_ == -1) return;  // @WZ: in case we shutdown due to disconnect
 
   unsigned int i;
   enum v4l2_buf_type type;
@@ -1085,7 +1086,7 @@ void UsbCam::grab_image(sensor_msgs::Image* msg)
 {
   // grab the image
   grab_image();
-  if (ENODEV == errno) return;
+  if (ENODEV == errno) return;  // @WZ: propagating ENODEV up, since image_ will be null
 
   // stamp the image
   msg->header.stamp = ros::Time::now();

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -526,9 +526,8 @@ int UsbCam::read_frame()
 
             /* fall through */
 
-          case ENODEV:
+          case ENODEV:  // @WZ: added to handle disconnection
             ROS_WARN("Connection to camera has been lost.");
-            this->shutdown();
             return 0;
 
           default:
@@ -583,7 +582,7 @@ int UsbCam::read_frame()
       break;
   }
 
-  image_->is_new = 1;
+  image_->is_new = 1;  // @WZ: moved from grab_image:1135 to handle ENODEV without segfaulting
   return 1;
 }
 
@@ -1086,7 +1085,7 @@ void UsbCam::grab_image(sensor_msgs::Image* msg)
 {
   // grab the image
   grab_image();
-  if (ENODEV == errno) return;
+  if (ENODEV == errno) return;  // @WZ: propagating ENODEV up, since image_ will be null
 
   // stamp the image
   msg->header.stamp = ros::Time::now();

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -526,7 +526,7 @@ int UsbCam::read_frame()
 
             /* fall through */
 
-          case ENODEV:  // @WZ: added to handle disconnection
+          case ENODEV:
             ROS_WARN("Connection to camera has been lost.");
             return 0;
 
@@ -581,7 +581,7 @@ int UsbCam::read_frame()
       break;
   }
 
-  image_->is_new = 1;  // @WZ: moved from grab_image:1135 to handle ENODEV without segfaulting
+  image_->is_new = 1;
   return 1;
 }
 
@@ -618,7 +618,7 @@ void UsbCam::start_capturing(void)
 {
 
   if(is_capturing_) return;
-  if (fd_ == -1) return;  // @WZ: in case we shutdown due to disconnect
+  if (fd_ == -1) return;
 
   unsigned int i;
   enum v4l2_buf_type type;
@@ -1085,7 +1085,7 @@ void UsbCam::grab_image(sensor_msgs::Image* msg)
 {
   // grab the image
   grab_image();
-  if (ENODEV == errno) return;  // @WZ: propagating ENODEV up, since image_ will be null
+  if (ENODEV == errno) return;
 
   // stamp the image
   msg->header.stamp = ros::Time::now();

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -539,9 +539,8 @@ int UsbCam::read_frame()
       len = buf.bytesused;
       process_image(buffers_[buf.index].start, len, image_);
 
-      if (-1 == xioctl(fd_, VIDIOC_QBUF, &buf)) {
+      if (-1 == xioctl(fd_, VIDIOC_QBUF, &buf)) 
         errno_exit("VIDIOC_QBUF");
-      }
 
       break;
 
@@ -619,6 +618,7 @@ void UsbCam::start_capturing(void)
 {
 
   if(is_capturing_) return;
+  if (fd_ == -1) return;  // @WZ: in case we shutdown due to disconnect
 
   unsigned int i;
   enum v4l2_buf_type type;


### PR DESCRIPTION
Included an error case (ENODEV) to handle when the USB cam is not detected (i.e. unplugged). Error is propagated up to the top level ROS node and handled there, which calls the cameras shutdown method and ROS node just stands by waiting for the connection to re-establish, wherein it starts the camera back up.